### PR TITLE
exclude desired_capacity from the ignore lifecycle

### DIFF
--- a/modules/node_groups/main.tf
+++ b/modules/node_groups/main.tf
@@ -99,7 +99,6 @@ resource "aws_eks_node_group" "workers" {
 
   lifecycle {
     create_before_destroy = true
-    ignore_changes        = [scaling_config[0].desired_size]
   }
 
 }


### PR DESCRIPTION
I'd like to  be able to apply changes on min and max capacity without being impacted by the desired_capacity value.
Currently TF is raising an error if we try to set the min capacity to higher value than the actual desired capacity